### PR TITLE
Fix OpenSearch mapper error from dots/brackets in query param keys

### DIFF
--- a/config/logstash/config/shared/pds-filter.conf
+++ b/config/logstash/config/shared/pds-filter.conf
@@ -673,6 +673,23 @@ filter {
         urldecode {
           field => "[url][query_params]"
         }
+        # Sanitize query param keys: dots/brackets in keys (e.g. nls[file][foo.nasl][1])
+        # are interpreted by OpenSearch as nested field paths, causing mapper cast errors.
+        # Replace . and [] characters with _ so keys are safe flat keyword field names.
+        ruby {
+          code => '
+            params = event.get("[url][query_params]")
+            if params.is_a?(Hash)
+              sanitized = {}
+              params.each do |k, v|
+                safe_key = k.gsub(/[\.\[\]]/, "_").gsub(/_+/, "_").gsub(/^_|_$/, "")
+                sanitized[safe_key] = v
+              end
+              event.set("[url][query_params]", sanitized)
+            end
+          '
+          id => "sanitize_query_param_keys"
+        }
         # Build url.query_parts: array of decoded "key=value" strings for wildcard filtering
         ruby {
           code => '


### PR DESCRIPTION
## 🗒️ Summary

Query param keys containing dots or square brackets (e.g. `nls[file][cmsmadesimple_nls_file_include.nasl][1]`) are interpreted by OpenSearch as nested field paths. When a conflicting keyword subfield already existed under `url.query_params` from a prior document, indexing an event with such a key caused a `KeywordFieldMapper cannot be cast to ObjectMapper` exception, dropping the event entirely.

Adds a Ruby filter block that sanitizes query param keys after URL-decoding: replaces `.`, `[`, and `]` with `_`, collapses repeated underscores, and strips leading/trailing underscores — producing safe flat keyword field names before indexing into `url.query_params`.

- [x] 🤖 This PR was developed with AI assistance (Claude Code) — logic reviewed and verified by author.

## ⚙️ Test Data and/or Report

Reproduced via the Logstash error log: events with bracket/dot query param keys (security scanner traffic hitting `/admin/lang.php?nls[file][...]=...`) were rejected with status 400. After this fix, keys are sanitized and events index successfully.

The existing integration tests in `tests/test_logstash_integration.py` cover the filter pipeline; no dedicated unit test added as this is a pure key-transformation with no branching logic beyond the existing `is_a?(Hash)` guard.

## ♻️ Related Issues

N/A — reactive fix for production indexing errors observed in Logstash logs.

## 🤓 Reviewer Checklist

- [ ] Are there any concerns about backward compatibility?
- [ ] Is the change tested?
- [ ] Are all relevant documentation updates included?

---

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)
